### PR TITLE
Export CLI helpers, add deterministic tests, and document workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Suno MV Maker – Electron App
 
 🎵 Generate a spectrum-visualized music video (MP4) from any [Suno](https://suno.com) song URL using this desktop Electron app.
@@ -22,10 +21,22 @@ npm install
 npm start
 ```
 
+## 🧪 Test
+
+```bash
+npm test
+```
+
+The automated tests cover deterministic CLI helper behavior only. They do not download Suno assets, launch Electron, invoke FFmpeg, or verify generated video playback.
+
 ## 🔧 Requirements
 
 - [Node.js](https://nodejs.org/)
 - [FFmpeg](https://ffmpeg.org/) installed and in PATH
+
+## 🧭 Development workflow
+
+See [docs/codex_workflow.md](docs/codex_workflow.md) for the current implementation rationale, accepted and rejected approaches, evaluation criteria, known constraints, unverified items, and failure examples.
 
 ## 📄 License
 

--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -1,0 +1,125 @@
+# Codex Work Log and Handoff Notes
+
+This document records the work style expected for this repository: confirm assumptions, inspect the existing design, define evaluation criteria before implementation, keep failed cases visible, and leave the project in a commit-ready state.
+
+## Repository context reviewed
+
+- `README.md` describes an Electron desktop app that creates MP4 music videos from Suno song URLs.
+- `src/main.js`, `src/preload.js`, `src/renderer.js`, and `public/index.html` implement the Electron UI flow.
+- `src/suno_mv.js` is a CLI-style implementation that downloads Suno audio/cover art and invokes FFmpeg.
+- `package.json` previously only exposed `npm start`; there was no automated test command.
+
+## Requirement interpretation
+
+The request is process-oriented rather than a new user-facing feature. The smallest useful implementation is therefore to make an existing seam testable, add automated evaluation cases, and document what was and was not verified.
+
+## Options considered
+
+### Adopted: extract pure helpers from the CLI and test them
+
+Why adopted:
+
+- It creates measurable behavior without launching Electron, downloading Suno assets, or invoking FFmpeg.
+- It keeps the implementation minimal and avoids broad integration work.
+- It makes URL parsing, path construction, CDN URL construction, and FFmpeg command construction independently reviewable.
+
+### Not adopted: rewrite the Electron main-process generation flow
+
+Why not adopted:
+
+- The request did not ask for a user-facing UI change.
+- Reworking IPC generation and settings would expand scope and create more unverified behavior.
+- It would likely require manual Electron and FFmpeg checks that are not safe to claim in this environment.
+
+### Not adopted: add an end-to-end FFmpeg/Suno network test
+
+Why not adopted:
+
+- It depends on external CDN availability, a valid public Suno URL, and local FFmpeg installation.
+- It may download copyrighted or user-provided media.
+- It would be slow and flaky compared with deterministic unit tests.
+
+## Evaluation criteria defined before implementation
+
+A change is considered acceptable when all of the following are true:
+
+1. `src/suno_mv.js` can still be executed directly as a CLI.
+2. Importing `src/suno_mv.js` from tests does not run downloads or FFmpeg.
+3. Suno song IDs can be extracted from standard `/song/<id>` URLs.
+4. Invalid URLs are rejected by returning `null` from the pure parser.
+5. CDN URL construction sanitizes IDs before embedding them in paths.
+6. Output paths are generated under the configured output directory.
+7. FFmpeg command construction preserves spaces in paths by quoting input and output paths.
+8. `npm test` runs the deterministic checks without Electron, network, or FFmpeg.
+
+## Failure conditions
+
+The work should be treated as failed if any of these occur:
+
+- Importing `src/suno_mv.js` starts a download, exits the process, or invokes FFmpeg.
+- The CLI entry point no longer works when `node src/suno_mv.js <Suno Song URL>` is used.
+- Tests require network access, Electron, or FFmpeg.
+- Tests only cover successful input and omit invalid or edge inputs.
+
+## Implemented changes
+
+- `src/suno_mv.js` now exports pure helper functions and only runs `main()` when executed directly.
+- `test/suno_mv.test.js` covers normal, invalid, and edge-oriented behavior for URL parsing and command construction.
+- `package.json` now includes `npm test`.
+
+## Test and evaluation cases
+
+Run:
+
+```bash
+npm test
+```
+
+Covered cases:
+
+- Standard Suno song URL extracts the song ID.
+- Non-song and malformed strings return `null`.
+- CDN asset URLs are built from a sanitized ID.
+- Generated MP3, JPEG, and MP4 paths remain under the output directory.
+- FFmpeg command includes the selected resolution and visualizer mode.
+- FFmpeg command quotes paths that include spaces.
+
+## Known constraints
+
+- The tests do not validate that Suno CDN URLs are currently reachable.
+- The tests do not validate that FFmpeg is installed or that a generated MP4 is playable.
+- The tests do not launch the Electron UI.
+- The FFmpeg command is still string-based because the existing implementation uses `child_process.exec`; switching to `spawn` with argument arrays would be a separate, safer refactor.
+
+## Unverified items
+
+- Real Suno download behavior with a live song URL.
+- Real FFmpeg rendering behavior and output media quality.
+- Electron renderer-to-main IPC behavior.
+- Windows-specific FFmpeg path behavior used by `src/main.js`.
+
+## Failed examples and handling
+
+These examples are intentionally represented in tests or documented as non-goals:
+
+- `https://suno.com/create` is not a song URL and should not produce a song ID.
+- `not a url` is malformed input and should not produce a song ID.
+- IDs containing path-like punctuation are sanitized before CDN URL construction.
+
+## User-facing explanation
+
+Users can keep running the app with:
+
+```bash
+npm start
+```
+
+Maintainers and contributors can now run deterministic checks with:
+
+```bash
+npm test
+```
+
+## Maintainer-facing explanation
+
+The CLI module now has a safe import boundary. Future work should add tests around pure helpers first, then add integration tests only when the environment can provide explicit sample media, FFmpeg, and permission to perform network downloads.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "src/main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "node test/suno_mv.test.js"
   },
   "devDependencies": {
     "electron": "^28.1.3"

--- a/src/suno_mv.js
+++ b/src/suno_mv.js
@@ -20,12 +20,49 @@ function download(url, dest) {
         });
     });
 }
+
 function extractSunoId(url) {
     const m = url.match(/song\/([a-f0-9-]+)/);
     return m ? m[1] : null;
 }
 
-async function main() {
+function sanitizeSunoId(songId) {
+    return songId.replace(/[^a-zA-Z0-9-_]/g, "");
+}
+
+function buildAssetUrls(songId) {
+    const safeId = sanitizeSunoId(songId);
+    return {
+        safeId,
+        mp3Url: `https://cdn1.suno.ai/${safeId}.mp3`,
+        defaultImageUrl: `https://cdn2.suno.ai/image_large_${safeId}.jpeg`,
+    };
+}
+
+function buildOutputPaths(outputPath, safeId) {
+    return {
+        mp3Path: path.join(outputPath, `${safeId}.mp3`),
+        imgPath: path.join(outputPath, `${safeId}.jpeg`),
+        mp4Path: path.join(outputPath, `${safeId}.mp4`),
+    };
+}
+
+function buildFfmpegCommand({ mp3Path, imgPath, mp4Path, resolution, visualizer }) {
+    return [
+        'ffmpeg', '-y',
+        '-i', `"${mp3Path}"`,
+        '-loop', '1',
+        '-i', `"${imgPath}"`,
+        '-filter_complex',
+        `"[0:a]showspectrum=s=${resolution}:mode=${visualizer}[spec];[1:v][spec]overlay=format=auto"`,
+        '-shortest',
+        '-c:v', 'libx264',
+        '-c:a', 'aac',
+        `"${mp4Path}"`
+    ].join(' ');
+}
+
+async function main(argv = process.argv) {
     const [
         ,,
         inputUrl,
@@ -33,21 +70,17 @@ async function main() {
         resolution = "1280x720",
         visualizer = "spectrum",
         imagePathOverride
-    ] = process.argv;
+    ] = argv;
 
-    if (!inputUrl || !extractSunoId(inputUrl)) {
+    const songId = inputUrl ? extractSunoId(inputUrl) : null;
+    if (!inputUrl || !songId) {
         console.error("Usage: node suno_mv.js <Suno Song URL>");
         process.exit(1);
     }
 
-    const songId = extractSunoId(inputUrl);
     if (!fs.existsSync(outputPath)) fs.mkdirSync(outputPath, { recursive: true });
-    const safeId = songId.replace(/[^a-zA-Z0-9-_]/g, "");
-    const mp3Url = `https://cdn1.suno.ai/${safeId}.mp3`;
-    const defaultImageUrl = `https://cdn2.suno.ai/image_large_${safeId}.jpeg`;
-    const mp3Path = path.join(outputPath, `${safeId}.mp3`);
-    const imgPath = path.join(outputPath, `${safeId}.jpeg`);
-    const mp4Path = path.join(outputPath, `${safeId}.mp4`);
+    const { safeId, mp3Url, defaultImageUrl } = buildAssetUrls(songId);
+    const { mp3Path, imgPath, mp4Path } = buildOutputPaths(outputPath, safeId);
 
     try {
         console.log("Downloading audio...");
@@ -73,18 +106,8 @@ async function main() {
             process.exit(4);
         }
     }
-    const ffmpegCmd = [
-        'ffmpeg', '-y',
-        '-i', `"${mp3Path}"`,
-        '-loop', '1',
-        '-i', `"${imgPath}"`,
-        '-filter_complex',
-        `"[0:a]showspectrum=s=${resolution}:mode=${visualizer}[spec];[1:v][spec]overlay=format=auto"`,
-        '-shortest',
-        '-c:v', 'libx264',
-        '-c:a', 'aac',
-        `"${mp4Path}"`
-    ].join(' ');
+
+    const ffmpegCmd = buildFfmpegCommand({ mp3Path, imgPath, mp4Path, resolution, visualizer });
 
     console.log("Generating video with FFmpeg...");
     exec(ffmpegCmd, (err, stdout, stderr) => {
@@ -95,4 +118,17 @@ async function main() {
         console.log(`✅ Done! Output saved to: ${mp4Path}`);
     });
 }
-main();
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    download,
+    extractSunoId,
+    sanitizeSunoId,
+    buildAssetUrls,
+    buildOutputPaths,
+    buildFfmpegCommand,
+    main,
+};

--- a/test/suno_mv.test.js
+++ b/test/suno_mv.test.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+const path = require('path');
+const {
+  extractSunoId,
+  buildAssetUrls,
+  buildOutputPaths,
+  buildFfmpegCommand,
+} = require('../src/suno_mv');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (error) {
+    console.error(`FAIL ${name}`);
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  }
+}
+
+test('extractSunoId accepts a standard Suno song URL', () => {
+  assert.strictEqual(
+    extractSunoId('https://suno.com/song/123e4567-e89b-12d3-a456-426614174000'),
+    '123e4567-e89b-12d3-a456-426614174000',
+  );
+});
+
+test('extractSunoId rejects non-song URLs', () => {
+  assert.strictEqual(extractSunoId('https://suno.com/create'), null);
+  assert.strictEqual(extractSunoId('not a url'), null);
+});
+
+test('buildAssetUrls sanitizes the ID before constructing CDN URLs', () => {
+  assert.deepStrictEqual(buildAssetUrls('abc-123_../evil'), {
+    safeId: 'abc-123_evil',
+    mp3Url: 'https://cdn1.suno.ai/abc-123_evil.mp3',
+    defaultImageUrl: 'https://cdn2.suno.ai/image_large_abc-123_evil.jpeg',
+  });
+});
+
+test('buildOutputPaths keeps generated files inside the output directory', () => {
+  const outputPath = path.join('tmp', 'out');
+  assert.deepStrictEqual(buildOutputPaths(outputPath, 'abc-123'), {
+    mp3Path: path.join(outputPath, 'abc-123.mp3'),
+    imgPath: path.join(outputPath, 'abc-123.jpeg'),
+    mp4Path: path.join(outputPath, 'abc-123.mp4'),
+  });
+});
+
+test('buildFfmpegCommand includes resolution, visualizer, and quoted paths', () => {
+  const command = buildFfmpegCommand({
+    mp3Path: 'tmp out/song.mp3',
+    imgPath: 'tmp out/song.jpeg',
+    mp4Path: 'tmp out/song.mp4',
+    resolution: '1920x1080',
+    visualizer: 'combined',
+  });
+
+  assert(command.includes('showspectrum=s=1920x1080:mode=combined'));
+  assert(command.includes('"tmp out/song.mp3"'));
+  assert(command.includes('"tmp out/song.jpeg"'));
+  assert(command.includes('"tmp out/song.mp4"'));
+});


### PR DESCRIPTION
### Motivation
- Create a safe import boundary so CLI logic can be unit-tested without performing network downloads or invoking FFmpeg. 
- Provide deterministic checks for URL parsing, ID sanitization, path construction, and FFmpeg command generation to make behavior reviewable. 
- Record the decision process, evaluation criteria, and known unverified items to make further work and handoff clear. 

### Description
- Refactored `src/suno_mv.js` to export pure helpers (`extractSunoId`, `sanitizeSunoId`, `buildAssetUrls`, `buildOutputPaths`, `buildFfmpegCommand`) and only run `main()` when the module is executed directly. 
- Replaced inline FFmpeg/URL/path construction with helper functions and used `buildFfmpegCommand` to centralize command generation. 
- Added deterministic unit tests at `test/suno_mv.test.js` covering standard and invalid URL parsing, ID sanitization, output path generation, and FFmpeg command quoting. 
- Added `npm test` to `package.json` and documented the workflow and constraints in `docs/codex_workflow.md`, plus a README update explaining the new test command. 

### Testing
- Ran `npm test`, which executed `test/suno_mv.test.js` and passed all checks for `extractSunoId`, `buildAssetUrls`, `buildOutputPaths`, and `buildFfmpegCommand`. 
- Tests are deterministic and do not perform network downloads, launch Electron, or call FFmpeg, and they all succeeded. 
- No integration tests against real CDN or FFmpeg were added due to external-dependency constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a480d73a42883338e77145d37e7e594)