### PR TITLE
Fix Tauri generate_mp4 command macro conflict

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,7 +128,7 @@ pub fn run_ffmpeg(args: &[String]) -> Result<(String, String), String> {
 }
 
 #[tauri::command]
-pub fn generate_mp4(app: AppHandle, request: GenerateRequest) -> GenerateResponse {
+fn generate_mp4(app: AppHandle, request: GenerateRequest) -> GenerateResponse {
     match generate_mp4_inner(app, request) {
         Ok(response) => response,
         Err(stderr) => GenerateResponse {


### PR DESCRIPTION
````markdown
## Summary

Fixes the Tauri `generate_mp4` command macro conflict found after PR #6 was merged.

## Context

After merging PR #6 and pulling latest `main`, local verification failed at:

```powershell
cargo check --manifest-path src-tauri/Cargo.toml
````

with Rust E0255:

```text
the name `__cmd__generate_mp4` is defined multiple times
the name `__tauri_command_name_generate_mp4` is defined multiple times
```

## Changes

* Updated `src-tauri/src/lib.rs`
* Fixed the `generate_mp4` Tauri command macro conflict
* Kept `generate_mp4` registered through `tauri::generate_handler![generate_mp4]`
* No behavior change intended

## Verification

Local branch:

```text
fix-tauri-command-macro
```

Commit:

```text
cf0d26c Fix Tauri generate_mp4 command macro conflict
```

Commands reported by Codex:

```text
cargo check --manifest-path src-tauri/Cargo.toml: pass
cargo test --manifest-path src-tauri/Cargo.toml: pass, 3 passed
npm test: pass, 1 passed
```

Local git status:

```text
ignored only:
node_modules/
src-tauri/gen/
src-tauri/target/
```

No generated/build artifacts are tracked.

## Note

This PR only fixes the Tauri command macro build failure.

A separate runtime issue remains: the app can launch and Preview works, but Generate MP4 currently fails with `program not found` because the Tauri runtime does not resolve `ffmpeg` even though `ffmpeg -version` works in PowerShell. That should be handled in a follow-up PR.

```
```
