### PR TITLE
Warm up Suno asset downloads

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,17 +101,47 @@ fn safe_id(id: &str) -> String {
         .collect()
 }
 
-fn download_to_file(url: &str, path: &Path) -> Result<(), String> {
-    let response = ureq::get(url).call().map_err(|err| match err {
+fn describe_download_error(context: &str, url: &str, err: ureq::Error) -> String {
+    match err {
         ureq::Error::Status(code, response) => format!(
-            "Download failed for {url}: HTTP {code} {}",
+            "{context} failed for {url}: HTTP {code} {}",
             response.status_text()
         ),
-        other => format!("Download failed for {url}: {other}"),
-    })?;
+        other => format!("{context} failed for {url}: {other}"),
+    }
+}
+
+fn download_to_file(agent: &ureq::Agent, url: &str, path: &Path) -> Result<(), String> {
+    let response = agent
+        .get(url)
+        .call()
+        .map_err(|err| describe_download_error("Download", url, err))?;
     let mut reader = response.into_reader();
     let mut file = fs::File::create(path).map_err(|err| err.to_string())?;
     std::io::copy(&mut reader, &mut file).map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+fn warm_up_direct_downloads(
+    agent: &ureq::Agent,
+    suno_url: &str,
+    cover_url: Option<&str>,
+) -> Result<(), String> {
+    agent
+        .get(suno_url)
+        .call()
+        .map(|_| ())
+        .map_err(|err| describe_download_error("Warm-up Suno page request", suno_url, err))?;
+
+    if let Some(cover_url) = cover_url {
+        agent
+            .get(cover_url)
+            .set("Range", "bytes=0-0")
+            .call()
+            .map(|_| ())
+            .map_err(|err| describe_download_error("Warm-up cover request", cover_url, err))?;
+    }
+
     Ok(())
 }
 
@@ -507,11 +537,25 @@ fn generate_mp4_inner(
     let cover_path = base_dir.join(format!("{id}.jpeg"));
     let output_path = base_dir.join(format!("{id}.mp4"));
 
-    download_to_file(&format!("https://cdn1.suno.ai/{id}.mp3"), &mp3_path)?;
+    let http_agent = ureq::AgentBuilder::new().build();
+    let mp3_url = format!("https://cdn1.suno.ai/{id}.mp3");
+    let cover_url = format!("https://cdn2.suno.ai/{id}.jpeg");
+    let has_frontend_cover = request.base64.is_some();
+    warm_up_direct_downloads(
+        &http_agent,
+        &request.url,
+        if has_frontend_cover {
+            None
+        } else {
+            Some(&cover_url)
+        },
+    )?;
+
+    download_to_file(&http_agent, &mp3_url, &mp3_path)?;
     if let Some(base64) = request.base64 {
         write_base64_image(&base64, &cover_path)?;
     } else {
-        download_to_file(&format!("https://cdn2.suno.ai/{id}.jpeg"), &cover_path)?;
+        download_to_file(&http_agent, &cover_url, &cover_path)?;
     }
 
     let args = build_ffmpeg_args(


### PR DESCRIPTION
````markdown
## Summary

Fix Suno cover fallback URL, AMD / AMF encode format, and direct download warm-up behavior.

## Changes

- Changed Suno cover fallback URL:
  - before: `https://cdn2.suno.ai/image_large_<id>.jpeg`
  - after: `https://cdn2.suno.ai/<id>.jpeg`
- Kept frontend cover image data / dropped image data URL as the first priority.
- Added direct-download warm-up only for the fallback path.
- Shared one `ureq::Agent` session across:
  - Suno song page warm-up
  - cover URL warm-up
  - MP3 download
  - JPEG fallback download
- Added cover fallback warm-up with lightweight `Range: bytes=0-0` GET.
- Skips cover fallback and warm-up when frontend cover data already exists.
- Improved warm-up/download errors to include URL, HTTP status, and detail.
- Fixed AMD / AMF encode input format.
- Ensured final video dimensions are even before encoding.
- Added explicit final video format:
  - CPU: `yuv420p`
  - AMD: `nv12`
- Added explicit `-map [v]` and `-map 0:a`.
- Kept CPU / x264 preset behavior unchanged.

## Notes

Suno cover images are not assumed to be square. The implementation preserves cover aspect ratio and only normalizes final encoded dimensions to even values.

## FFmpeg h264_amf check

`ffmpeg -hide_banner -h encoder=h264_amf`

Confirmed locally:

- Supported pixel formats: `nv12 yuv420p d3d11 dxva2_vld p010le amf bgr0 rgb0 bgra argb rgba x2bgr10le rgbaf16le`
- `usage`: `transcoding`, `ultralowlatency`, `lowlatency`, `webcam`, `high_quality`, `lowlatency_high_quality`
- `quality`: `balanced`, `speed`, `quality`
- `h264_amf`: enabled

## Final filter_complex

CPU:

```text
[0:a]showspectrum=s={resolution}:mode={visualizer}[spec];[1:v][spec]overlay=format=auto,scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p[v]
````

AMD:

```text
[0:a]showspectrum=s={resolution}:mode={visualizer}[spec];[1:v][spec]overlay=format=auto,scale=trunc(iw/2)*2:trunc(ih/2)*2,format=nv12[v]
```

## Verification

* `cargo check --manifest-path src-tauri/Cargo.toml`: pass
* `cargo test --manifest-path src-tauri/Cargo.toml`: pass
* `npm test`: pass
* `npm start`: not run

## Commits

* `5e5d20c` — cover fallback URL and AMF format fix
* `4d94e8e` — warm-up access before direct Suno asset downloads

## Branch

`fix-cover-url-and-amd-format`

## Artifact guard

No generated files, build artifacts, installer files, or FFmpeg binaries should be committed.

```
```
