### PR TITLE
Add Suno metadata UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,22 +4,26 @@
     <meta charset="UTF-8" >
     <title>Suno MV App</title>
     <style>
-        body { font-family: sans-serif; padding: 20px; color: #222; }
-        button, input, select { font: inherit; }
+        body { font-family: sans-serif; padding: 20px; color: #222; max-width: 980px; margin: 0 auto; }
+        button, input, select, textarea { font: inherit; }
         button { margin: 4px 4px 4px 0; }
+        input[type="text"], input[type="password"], input[type="number"], textarea { box-sizing: border-box; width: 100%; }
+        .main-actions { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 8px 0; }
+        #status-line { margin: 10px 0; font-weight: 700; }
+        #output-result { margin: 6px 0 14px; word-break: break-all; }
         #drop-area {
-            width: 100%; height: 200px; border: 2px dashed #aaa;
+            width: 100%; min-height: 160px; border: 2px dashed #aaa;
             display: flex; justify-content: center; align-items: center;
-            margin-bottom: 10px;
+            margin: 10px 0;
         }
         #preview-img {
-            max-width: 100%; max-height: 150px;
+            max-width: 100%; max-height: 220px;
             display: block; margin-top: 10px;
         }
         details {
             border: 1px solid #d4d4d4;
             padding: 12px;
-            margin: 14px 0;
+            margin: 12px 0;
         }
         summary { cursor: pointer; font-weight: 700; }
         fieldset {
@@ -29,20 +33,29 @@
         }
         label { display: block; margin: 8px 0; }
         .settings-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-        .settings-row input[type="text"] { flex: 1 1 320px; min-width: 220px; }
-        #ffmpeg-status { white-space: pre-wrap; margin-top: 8px; }
+        .settings-row input[type="text"], .settings-row input[type="password"] { flex: 1 1 320px; min-width: 220px; }
+        .hint { color: #666; font-size: 0.92rem; }
+        .panel-output { white-space: pre-wrap; word-break: break-word; }
+        #log { max-height: 260px; overflow: auto; }
     </style>
 </head>
 <body>
     <h1>Suno MV Maker</h1>
-    
-    <input id="url-input" type="text" placeholder="Paste Suno URL here" style="width: 100%;" >
-    <button id="preview-btn">Preview</button>
-    <button id="generate-btn">Generate MP4</button>
 
-    <details id="settings-panel">
-        <summary>Settings</summary>
+    <label for="url-input">Suno URL</label>
+    <input id="url-input" type="text" placeholder="Paste Suno URL here" >
+    <div class="main-actions">
+        <button id="preview-btn">Preview</button>
+        <button id="generate-btn">Generate MP4</button>
+    </div>
+    <div id="status-line">Idle</div>
+    <div id="output-result"></div>
 
+    <div id="drop-area">Drag and drop cover image here</div>
+    <img id="preview-img" src="" alt="Cover Preview" >
+
+    <details id="render-settings-panel" open>
+        <summary>Render Settings</summary>
         <fieldset>
             <legend>Output</legend>
             <label for="save-folder-input">Save folder</label>
@@ -65,7 +78,7 @@
                 <button id="choose-ffmpeg-btn" type="button">Choose ffmpeg.exe</button>
                 <button id="test-ffmpeg-btn" type="button">Test FFmpeg</button>
             </div>
-            <div id="ffmpeg-status">Status: Not tested</div>
+            <div id="ffmpeg-status" class="panel-output">Status: Not tested</div>
         </fieldset>
 
         <fieldset>
@@ -82,11 +95,59 @@
                 <option value="high">High</option>
             </select>
         </fieldset>
+
+        <fieldset>
+            <legend>Render</legend>
+            <label for="resolution-input">Resolution</label>
+            <select id="resolution-input">
+                <option value="1280x720">1280x720</option>
+                <option value="1920x1080">1920x1080</option>
+                <option value="1080x1080">1080x1080</option>
+            </select>
+
+            <label for="visualizer-input">Visualizer</label>
+            <select id="visualizer-input">
+                <option value="combined">combined</option>
+                <option value="separate">separate</option>
+                <option value="single">single</option>
+            </select>
+        </fieldset>
     </details>
 
-    <div id="drop-area">Drag and drop cover image here</div>
-    <img id="preview-img" src="" alt="Cover Preview" >
-    <pre id="log"></pre>
+    <details id="suno-api-settings-panel">
+        <summary>Suno API Settings</summary>
+        <p class="hint">Suno API values are optional and stored locally in app settings.</p>
+        <label for="suno-authorization-input">authorization</label>
+        <input id="suno-authorization-input" type="password" autocomplete="off" >
+        <label for="suno-browser-token-input">browser-token</label>
+        <input id="suno-browser-token-input" type="password" autocomplete="off" >
+        <label for="suno-device-id-input">device-id</label>
+        <input id="suno-device-id-input" type="password" autocomplete="off" >
+        <label for="suno-max-pages-input">max pages</label>
+        <input id="suno-max-pages-input" type="number" min="1" max="1000" value="100" >
+        <button id="test-metadata-btn" type="button">Test metadata fetch</button>
+        <div id="suno-api-status" class="panel-output">Not tested</div>
+    </details>
+
+    <details id="metadata-panel">
+        <summary>Metadata</summary>
+        <div id="metadata-output" class="panel-output">No metadata loaded.</div>
+    </details>
+
+    <details id="lyrics-panel">
+        <summary>Lyrics</summary>
+        <div id="lyrics-output" class="panel-output">No lyrics metadata loaded.</div>
+    </details>
+
+    <details id="prompt-panel">
+        <summary>Style / Prompt</summary>
+        <div id="prompt-output" class="panel-output">No prompt metadata loaded.</div>
+    </details>
+
+    <details id="log-panel">
+        <summary>Log</summary>
+        <pre id="log"></pre>
+    </details>
 
     <script src="renderer.js"></script>
 </body>

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -6,6 +6,39 @@ const invoke = async (command, args) => {
     return tauriInvoke(command, args);
 };
 
+const extractSunoId = (url) => {
+    const match = url.match(/suno\.com\/(?:song|s)\/([a-f0-9-]+)/i);
+    return match ? match[1] : null;
+};
+
+const maskSecret = (value) => {
+    const trimmed = (value || "").trim();
+    if (!trimmed) return "";
+    const parts = trimmed.split(/\s+/, 2);
+    if (parts.length === 2) {
+        return `${parts[0]} ${maskToken(parts[1])}`;
+    }
+    return maskToken(trimmed);
+};
+
+const maskToken = (value) => {
+    if (value.length <= 6) return "***";
+    return `${value.slice(0, 3)}...${value.slice(-3)}`;
+};
+
+const hasSunoApiSettings = (settings) => Boolean(
+    settings.suno_authorization?.trim() &&
+    settings.suno_browser_token?.trim() &&
+    settings.suno_device_id?.trim()
+);
+
+const selectAudioSource = (metadata, fallback) => metadata?.audioUrl || fallback;
+
+const selectCoverSource = (frontendData, metadata, fallback) => {
+    if (frontendData) return frontendData;
+    return metadata?.imageLargeUrl || metadata?.imageUrl || fallback;
+};
+
 window.onload = () => {
     const urlInput = document.getElementById("url-input");
     const previewBtn = document.getElementById("preview-btn");
@@ -13,6 +46,8 @@ window.onload = () => {
     const dropArea = document.getElementById("drop-area");
     const previewImg = document.getElementById("preview-img");
     const logArea = document.getElementById("log");
+    const statusLine = document.getElementById("status-line");
+    const outputResult = document.getElementById("output-result");
     const saveFolderInput = document.getElementById("save-folder-input");
     const chooseFolderBtn = document.getElementById("choose-folder-btn");
     const openFolderBtn = document.getElementById("open-folder-btn");
@@ -23,13 +58,70 @@ window.onload = () => {
     const ffmpegStatus = document.getElementById("ffmpeg-status");
     const encoderPresetInput = document.getElementById("encoder-preset-input");
     const qualityInput = document.getElementById("quality-input");
+    const resolutionInput = document.getElementById("resolution-input");
+    const visualizerInput = document.getElementById("visualizer-input");
+    const sunoAuthorizationInput = document.getElementById("suno-authorization-input");
+    const sunoBrowserTokenInput = document.getElementById("suno-browser-token-input");
+    const sunoDeviceIdInput = document.getElementById("suno-device-id-input");
+    const sunoMaxPagesInput = document.getElementById("suno-max-pages-input");
+    const testMetadataBtn = document.getElementById("test-metadata-btn");
+    const sunoApiStatus = document.getElementById("suno-api-status");
+    const metadataOutput = document.getElementById("metadata-output");
+    const lyricsOutput = document.getElementById("lyrics-output");
+    const promptOutput = document.getElementById("prompt-output");
+
+    let currentMetadata = null;
+    let currentSongId = null;
 
     const defaultSettings = {
         save_folder: "",
         ffmpeg_auto_detect: true,
         ffmpeg_path: "",
         encoder_preset: "cpu_x264",
-        quality: "standard"
+        quality: "standard",
+        suno_authorization: "",
+        suno_browser_token: "",
+        suno_device_id: "",
+        suno_max_pages: 100
+    };
+
+    const setStatus = (status) => {
+        statusLine.textContent = status;
+    };
+
+    const appendLog = (message) => {
+        logArea.textContent += `${message}\n`;
+        logArea.scrollTop = logArea.scrollHeight;
+    };
+
+    const resetMetadataUi = () => {
+        currentMetadata = null;
+        metadataOutput.textContent = "No metadata loaded.";
+        lyricsOutput.textContent = "No lyrics metadata loaded.";
+        promptOutput.textContent = "No prompt metadata loaded.";
+    };
+
+    const renderMetadata = (metadata) => {
+        if (!metadata) {
+            resetMetadataUi();
+            return;
+        }
+
+        metadataOutput.textContent = [
+            ["title", metadata.title],
+            ["id", metadata.id],
+            ["display_name", metadata.displayName],
+            ["created_at", metadata.createdAt],
+            ["audio_url", metadata.audioUrl],
+            ["image_url", metadata.imageUrl],
+            ["image_large_url", metadata.imageLargeUrl],
+            ["video_url", metadata.videoUrl]
+        ]
+            .filter(([, value]) => value)
+            .map(([label, value]) => `${label}: ${value}`)
+            .join("\n") || "No metadata loaded.";
+        lyricsOutput.textContent = metadata.lyrics || "No lyrics metadata loaded.";
+        promptOutput.textContent = metadata.prompt || "No prompt metadata loaded.";
     };
 
     const getSettingsFromUi = () => ({
@@ -37,7 +129,11 @@ window.onload = () => {
         ffmpeg_auto_detect: ffmpegAutoDetectInput.checked,
         ffmpeg_path: ffmpegPathInput.value.trim(),
         encoder_preset: encoderPresetInput.value,
-        quality: qualityInput.value
+        quality: qualityInput.value,
+        suno_authorization: sunoAuthorizationInput.value.trim(),
+        suno_browser_token: sunoBrowserTokenInput.value.trim(),
+        suno_device_id: sunoDeviceIdInput.value.trim(),
+        suno_max_pages: Math.max(1, Number.parseInt(sunoMaxPagesInput.value, 10) || 100)
     });
 
     const applySettingsToUi = (settings) => {
@@ -47,6 +143,10 @@ window.onload = () => {
         ffmpegPathInput.value = merged.ffmpeg_path || "";
         encoderPresetInput.value = merged.encoder_preset || "cpu_x264";
         qualityInput.value = merged.quality || "standard";
+        sunoAuthorizationInput.value = merged.suno_authorization || "";
+        sunoBrowserTokenInput.value = merged.suno_browser_token || "";
+        sunoDeviceIdInput.value = merged.suno_device_id || "";
+        sunoMaxPagesInput.value = merged.suno_max_pages || 100;
         syncFfmpegControls();
     };
 
@@ -92,19 +192,46 @@ window.onload = () => {
         try {
             const response = await fetch(src, { mode: "cors" });
             if (!response.ok) {
-                logArea.textContent += `\nPreview image fetch failed: ${response.status} ${response.statusText}`;
+                appendLog(`preview cover fetch failed: ${response.status} ${response.statusText}`);
                 return null;
             }
             const blob = await response.blob();
             if (!blob.type.startsWith("image/")) {
-                logArea.textContent += `\nPreview image fetch did not return an image: ${blob.type || "unknown type"}`;
+                appendLog(`preview cover fetch did not return an image: ${blob.type || "unknown type"}`);
                 return null;
             }
             return await blobToDataUrl(blob);
         } catch (e) {
-            logArea.textContent += "\nPreview image fetch failed: " + e.message;
+            appendLog("preview cover fetch failed: " + e.message);
             return null;
         }
+    };
+
+    const fetchMetadata = async (url) => {
+        const settings = getSettingsFromUi();
+        if (!hasSunoApiSettings(settings)) {
+            appendLog("metadata fetch skipped: Suno API settings are not configured");
+            setStatus("Preview OK");
+            sunoApiStatus.textContent = "Suno API settings are not configured.";
+            return null;
+        }
+
+        await saveSettings();
+        appendLog("metadata fetch start");
+        appendLog(`authorization ${maskSecret(settings.suno_authorization)}`);
+        appendLog(`browser-token ${maskSecret(settings.suno_browser_token)}`);
+        appendLog(`device-id ${maskSecret(settings.suno_device_id)}`);
+        const result = await invoke("fetch_suno_metadata", { url });
+        (result.logs || []).forEach(appendLog);
+        sunoApiStatus.textContent = result.status || "Metadata fetch finished.";
+        if (result.success && result.metadata) {
+            currentMetadata = result.metadata;
+            renderMetadata(currentMetadata);
+            setStatus("Metadata found");
+            return currentMetadata;
+        }
+        setStatus("Metadata unavailable, using fallback");
+        return null;
     };
 
     invoke("load_settings")
@@ -114,19 +241,24 @@ window.onload = () => {
             ffmpegStatus.textContent = "Status: Settings load failed\n" + e.message;
         });
 
-    [saveFolderInput, ffmpegPathInput, encoderPresetInput, qualityInput].forEach((element) => {
+    [
+        saveFolderInput,
+        ffmpegPathInput,
+        encoderPresetInput,
+        qualityInput,
+        sunoAuthorizationInput,
+        sunoBrowserTokenInput,
+        sunoDeviceIdInput,
+        sunoMaxPagesInput
+    ].forEach((element) => {
         element.addEventListener("change", () => {
-            saveSettings().catch((e) => {
-                logArea.textContent += "\nSettings save failed: " + e.message;
-            });
+            saveSettings().catch((e) => appendLog("settings save failed: " + e.message));
         });
     });
 
     ffmpegAutoDetectInput.addEventListener("change", () => {
         syncFfmpegControls();
-        saveSettings().catch((e) => {
-            logArea.textContent += "\nSettings save failed: " + e.message;
-        });
+        saveSettings().catch((e) => appendLog("settings save failed: " + e.message));
     });
 
     chooseFolderBtn.onclick = async () => {
@@ -151,7 +283,7 @@ window.onload = () => {
             const opened = await invoke("open_output_folder", {
                 saveFolder: saveFolderInput.value.trim() || null
             });
-            logArea.textContent += `\nOpened folder: ${opened}`;
+            appendLog(`opened folder: ${opened}`);
         } catch (e) {
             alert("フォルダを開けませんでした\n\n" + e.message);
         }
@@ -168,17 +300,51 @@ window.onload = () => {
         }
     };
 
-    previewBtn.onclick = () => {
+    testMetadataBtn.onclick = async () => {
         const url = urlInput.value.trim();
-        const m = url.match(/song\/([a-f0-9-]+)/);
-        if (m) {
-            const id = m[1];
-            previewImg.src = `https://cdn2.suno.ai/image_large_${id}.jpeg`;
-            previewImg.setAttribute("data-cover-id", id);
-            previewImg.removeAttribute("data-base64");
-        } else {
+        if (!extractSunoId(url)) {
+            sunoApiStatus.textContent = "Enter a Suno URL first.";
+            return;
+        }
+        try {
+            const metadata = await fetchMetadata(url);
+            sunoApiStatus.textContent = metadata ? "Metadata found" : "Metadata unavailable, using fallback";
+        } catch (e) {
+            sunoApiStatus.textContent = "Metadata fetch failed: " + e.message;
+            appendLog("metadata fetch failed: " + e.message);
+        }
+    };
+
+    previewBtn.onclick = async () => {
+        const url = urlInput.value.trim();
+        const id = extractSunoId(url);
+        if (!id) {
             previewImg.src = "";
+            setStatus("Failed");
             alert("Suno曲のURLを正しく入力してください");
+            return;
+        }
+
+        currentSongId = id;
+        resetMetadataUi();
+        outputResult.textContent = "";
+        previewImg.src = `https://cdn2.suno.ai/${id}.jpeg`;
+        previewImg.setAttribute("data-cover-id", id);
+        previewImg.removeAttribute("data-base64");
+        appendLog(`id extraction: ${id}`);
+        appendLog(`preview cover source: cdn2 fallback https://cdn2.suno.ai/${id}.jpeg`);
+        setStatus("Preview OK");
+
+        try {
+            const metadata = await fetchMetadata(url);
+            const metadataCover = metadata?.imageLargeUrl || metadata?.imageUrl;
+            if (metadataCover && previewImg.getAttribute("data-cover-id") !== "custom") {
+                previewImg.src = metadataCover;
+                appendLog(`preview cover source: metadata ${metadataCover}`);
+            }
+        } catch (e) {
+            appendLog("metadata fetch failed: " + e.message);
+            setStatus("Metadata unavailable, using fallback");
         }
     };
 
@@ -203,7 +369,8 @@ window.onload = () => {
                 previewImg.src = base64;
                 previewImg.setAttribute("data-cover-id", "custom");
                 previewImg.setAttribute("data-base64", base64);
-                logArea.textContent += "\nCover image loaded from local file.";
+                appendLog("preview cover source: dropped frontend data URL");
+                setStatus("Preview OK");
             };
             reader.onerror = () => {
                 alert("画像ファイルを読み込めませんでした");
@@ -216,47 +383,57 @@ window.onload = () => {
 
     generateBtn.onclick = async () => {
         const url = urlInput.value.trim();
-        const m = url.match(/song\/([a-f0-9-]+)/);
-        if (!m) {
+        const id = extractSunoId(url);
+        if (!id) {
             alert("Suno曲のURLを正しく入力してください");
             return;
         }
 
-        logArea.textContent = "動画生成中…\n";
+        setStatus("Rendering");
+        outputResult.textContent = "";
         try {
             await saveSettings();
+            const fallbackAudio = `https://cdn1.suno.ai/${id}.mp3`;
+            const fallbackCover = `https://cdn2.suno.ai/${id}.jpeg`;
+            const metadataForRequest = currentSongId === id ? currentMetadata : null;
             const base64 = await resolveCoverBase64();
-            if (base64) {
-                logArea.textContent += "Using frontend cover image data.\n";
-            } else {
-                logArea.textContent += "No frontend cover image data; Rust will try the cdn2 fallback.\n";
-            }
+            const selectedAudio = selectAudioSource(metadataForRequest, fallbackAudio);
+            const selectedCover = selectCoverSource(base64, metadataForRequest, fallbackCover);
+            appendLog(`selected audio source: ${selectedAudio}`);
+            appendLog(`selected cover source: ${base64 ? "frontend data URL" : selectedCover}`);
+
             const result = await invoke("generate_mp4", {
                 request: {
                     url,
                     base64,
-                    resolution: "1280x720",
-                    visualizer: "combined",
+                    resolution: resolutionInput.value,
+                    visualizer: visualizerInput.value,
                     outputDir: saveFolderInput.value.trim() || null,
                     ffmpegAutoDetect: ffmpegAutoDetectInput.checked,
                     ffmpegPath: ffmpegPathInput.value.trim(),
                     encoderPreset: encoderPresetInput.value,
-                    quality: qualityInput.value
+                    quality: qualityInput.value,
+                    audioUrl: metadataForRequest?.audioUrl || null,
+                    metadataImageUrl: metadataForRequest?.imageLargeUrl || metadataForRequest?.imageUrl || null,
+                    outputFilename: metadataForRequest?.title || null
                 }
             });
 
             if (result.success) {
-                alert(`✅ 完了！出力先: ${result.outputPath || "output"}`);
-                logArea.textContent += result.stdout || result.stderr || "完了しました";
+                setStatus("Done");
+                outputResult.textContent = result.outputPath || "output";
+                appendLog(`output path: ${result.outputPath || "output"}`);
+                if (result.stderr) appendLog(`FFmpeg stderr:\n${result.stderr}`);
+                if (result.stdout) appendLog(`FFmpeg stdout:\n${result.stdout}`);
             } else {
+                setStatus("Failed");
+                appendLog(result.stderr || "render failed without details");
                 alert("動画生成中にエラーが発生しました\n\n" + (result.stderr || "詳細不明"));
-                logArea.textContent += (result.stderr || "") + "\n" + (result.stdout || "");
             }
         } catch (e) {
+            setStatus("Failed");
+            appendLog("IPC error: " + e.message);
             alert("IPC通信エラー:\n\n" + e.message);
-            logArea.textContent += "IPCエラー: " + e.message;
         }
-
-        logArea.scrollTop = logArea.scrollHeight;
     };
 };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri::{AppHandle, Manager};
@@ -16,12 +16,17 @@ const SETTINGS_FILE_NAME: &str = "settings.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[serde(default)]
 pub struct AppSettings {
     pub save_folder: String,
     pub ffmpeg_auto_detect: bool,
     pub ffmpeg_path: String,
     pub encoder_preset: String,
     pub quality: String,
+    pub suno_authorization: String,
+    pub suno_browser_token: String,
+    pub suno_device_id: String,
+    pub suno_max_pages: u32,
 }
 
 impl Default for AppSettings {
@@ -32,6 +37,10 @@ impl Default for AppSettings {
             ffmpeg_path: String::new(),
             encoder_preset: "cpu_x264".to_string(),
             quality: "standard".to_string(),
+            suno_authorization: String::new(),
+            suno_browser_token: String::new(),
+            suno_device_id: String::new(),
+            suno_max_pages: 100,
         }
     }
 }
@@ -48,6 +57,9 @@ pub struct GenerateRequest {
     pub ffmpeg_path: Option<String>,
     pub encoder_preset: Option<String>,
     pub quality: Option<String>,
+    pub audio_url: Option<String>,
+    pub metadata_image_url: Option<String>,
+    pub output_filename: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -69,8 +81,38 @@ pub struct FfmpegTestResponse {
     pub details: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SunoMetadata {
+    pub id: Option<String>,
+    pub title: Option<String>,
+    pub display_name: Option<String>,
+    pub created_at: Option<String>,
+    pub audio_url: Option<String>,
+    pub video_url: Option<String>,
+    pub image_url: Option<String>,
+    pub image_large_url: Option<String>,
+    pub prompt: Option<String>,
+    pub lyrics: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataFetchResponse {
+    pub success: bool,
+    pub status: String,
+    pub song_id: Option<String>,
+    pub metadata: Option<SunoMetadata>,
+    pub pages_checked: u32,
+    pub logs: Vec<String>,
+}
+
 pub fn extract_suno_id(url: &str) -> Option<String> {
-    let marker = "/song/";
+    let marker = if url.contains("/song/") {
+        "/song/"
+    } else {
+        "/s/"
+    };
     let start = url.find(marker)? + marker.len();
     let id: String = url[start..]
         .chars()
@@ -81,6 +123,99 @@ pub fn extract_suno_id(url: &str) -> Option<String> {
         None
     } else {
         Some(id)
+    }
+}
+
+pub fn mask_secret(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if let Some((prefix, token)) = trimmed.split_once(' ') {
+        if !token.is_empty() {
+            return format!("{prefix} {}", mask_token(token));
+        }
+    }
+
+    mask_token(trimmed)
+}
+
+fn mask_token(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() <= 6 {
+        return "***".to_string();
+    }
+    let start: String = chars.iter().take(3).collect();
+    let end: String = chars
+        .iter()
+        .rev()
+        .take(3)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("{start}...{end}")
+}
+
+pub fn has_suno_api_settings(settings: &AppSettings) -> bool {
+    !settings.suno_authorization.trim().is_empty()
+        && !settings.suno_browser_token.trim().is_empty()
+        && !settings.suno_device_id.trim().is_empty()
+}
+
+pub fn select_audio_source(metadata: Option<&SunoMetadata>, fallback: &str) -> String {
+    metadata
+        .and_then(|metadata| metadata.audio_url.as_deref())
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+pub fn select_cover_source(
+    frontend_data: Option<&str>,
+    metadata: Option<&SunoMetadata>,
+    fallback: &str,
+) -> String {
+    if let Some(frontend_data) = frontend_data {
+        if !frontend_data.trim().is_empty() {
+            return frontend_data.to_string();
+        }
+    }
+
+    metadata
+        .and_then(|metadata| {
+            metadata
+                .image_large_url
+                .as_deref()
+                .or(metadata.image_url.as_deref())
+        })
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+pub fn find_matching_clip(clips: &[SunoMetadata], id: &str) -> Option<SunoMetadata> {
+    clips
+        .iter()
+        .find(|clip| clip.id.as_deref() == Some(id))
+        .cloned()
+}
+
+fn safe_filename(value: &str) -> String {
+    let name: String = value
+        .chars()
+        .map(|ch| match ch {
+            '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
+            ch if ch.is_control() => '_',
+            ch => ch,
+        })
+        .collect();
+    let trimmed = name.trim().trim_matches('.').to_string();
+    if trimmed.is_empty() {
+        "suno_mv".to_string()
+    } else {
+        trimmed.chars().take(120).collect()
     }
 }
 
@@ -120,6 +255,187 @@ fn download_to_file(agent: &ureq::Agent, url: &str, path: &Path) -> Result<(), S
     let mut file = fs::File::create(path).map_err(|err| err.to_string())?;
     std::io::copy(&mut reader, &mut file).map_err(|err| err.to_string())?;
     Ok(())
+}
+
+fn metadata_from_value(value: &serde_json::Value) -> SunoMetadata {
+    SunoMetadata {
+        id: value
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        title: value
+            .get("title")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        display_name: value
+            .get("display_name")
+            .or_else(|| value.get("displayName"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        created_at: value
+            .get("created_at")
+            .or_else(|| value.get("createdAt"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        audio_url: value
+            .get("audio_url")
+            .or_else(|| value.get("audioUrl"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        video_url: value
+            .get("video_url")
+            .or_else(|| value.get("videoUrl"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        image_url: value
+            .get("image_url")
+            .or_else(|| value.get("imageUrl"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        image_large_url: value
+            .get("image_large_url")
+            .or_else(|| value.get("imageLargeUrl"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        prompt: value
+            .get("prompt")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        lyrics: value
+            .get("lyrics")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+    }
+}
+
+fn clips_from_feed_value(value: &serde_json::Value) -> Vec<SunoMetadata> {
+    if let Some(items) = value.as_array() {
+        return items.iter().map(metadata_from_value).collect();
+    }
+
+    for key in ["clips", "data", "items"] {
+        if let Some(items) = value.get(key).and_then(|value| value.as_array()) {
+            return items.iter().map(metadata_from_value).collect();
+        }
+    }
+
+    Vec::new()
+}
+
+fn fetch_suno_metadata_inner(
+    agent: &ureq::Agent,
+    settings: &AppSettings,
+    song_id: &str,
+) -> MetadataFetchResponse {
+    let max_pages = settings.suno_max_pages.max(1);
+    let mut logs = vec![
+        format!("metadata fetch start: id={song_id}"),
+        format!(
+            "authorization {}",
+            mask_secret(&settings.suno_authorization)
+        ),
+        format!(
+            "browser-token {}",
+            mask_secret(&settings.suno_browser_token)
+        ),
+        format!("device-id {}", mask_secret(&settings.suno_device_id)),
+    ];
+
+    if !has_suno_api_settings(settings) {
+        logs.push("Suno API settings are not configured.".to_string());
+        return MetadataFetchResponse {
+            success: false,
+            status: "Suno API settings are not configured.".to_string(),
+            song_id: Some(song_id.to_string()),
+            metadata: None,
+            pages_checked: 0,
+            logs,
+        };
+    }
+
+    for page in 0..max_pages {
+        let url = format!("https://studio-api-prod.suno.com/api/feed/?page={page}");
+        logs.push(format!("metadata fetch page={page}"));
+        let response = match agent
+            .get(&url)
+            .set("authorization", settings.suno_authorization.trim())
+            .set("browser-token", settings.suno_browser_token.trim())
+            .set("device-id", settings.suno_device_id.trim())
+            .set("accept", "*/*")
+            .set("content-type", "application/json")
+            .call()
+        {
+            Ok(response) => response,
+            Err(err) => {
+                let status = describe_download_error("Metadata fetch", &url, err);
+                logs.push(status.clone());
+                return MetadataFetchResponse {
+                    success: false,
+                    status,
+                    song_id: Some(song_id.to_string()),
+                    metadata: None,
+                    pages_checked: page + 1,
+                    logs,
+                };
+            }
+        };
+
+        let mut text = String::new();
+        let value = match response
+            .into_reader()
+            .read_to_string(&mut text)
+            .map_err(|err| err.to_string())
+            .and_then(|_| {
+                serde_json::from_str::<serde_json::Value>(&text).map_err(|err| err.to_string())
+            }) {
+            Ok(value) => value,
+            Err(err) => {
+                let status = format!("Metadata fetch failed for {url}: invalid JSON: {err}");
+                logs.push(status.clone());
+                return MetadataFetchResponse {
+                    success: false,
+                    status,
+                    song_id: Some(song_id.to_string()),
+                    metadata: None,
+                    pages_checked: page + 1,
+                    logs,
+                };
+            }
+        };
+        let clips = clips_from_feed_value(&value);
+        logs.push(format!("metadata page={page} clips={}", clips.len()));
+        if clips.is_empty() {
+            return MetadataFetchResponse {
+                success: false,
+                status: "Metadata unavailable, using fallback".to_string(),
+                song_id: Some(song_id.to_string()),
+                metadata: None,
+                pages_checked: page + 1,
+                logs,
+            };
+        }
+        if let Some(metadata) = find_matching_clip(&clips, song_id) {
+            logs.push(format!("metadata match page={page} id={song_id}"));
+            return MetadataFetchResponse {
+                success: true,
+                status: "Metadata found".to_string(),
+                song_id: Some(song_id.to_string()),
+                metadata: Some(metadata),
+                pages_checked: page + 1,
+                logs,
+            };
+        }
+    }
+
+    logs.push(format!("metadata match not found within {max_pages} pages"));
+    MetadataFetchResponse {
+        success: false,
+        status: "Metadata unavailable, using fallback".to_string(),
+        song_id: Some(song_id.to_string()),
+        metadata: None,
+        pages_checked: max_pages,
+        logs,
+    }
 }
 
 fn warm_up_direct_downloads(
@@ -493,6 +809,38 @@ fn open_output_folder(app: AppHandle, save_folder: Option<String>) -> Result<Str
 }
 
 #[tauri::command]
+fn fetch_suno_metadata(app: AppHandle, url: String) -> MetadataFetchResponse {
+    let settings = match read_settings(&app) {
+        Ok(settings) => settings,
+        Err(err) => {
+            return MetadataFetchResponse {
+                success: false,
+                status: format!("Settings load failed: {err}"),
+                song_id: None,
+                metadata: None,
+                pages_checked: 0,
+                logs: vec![format!("Settings load failed: {err}")],
+            };
+        }
+    };
+    let song_id = match extract_suno_id(&url) {
+        Some(song_id) => song_id,
+        None => {
+            return MetadataFetchResponse {
+                success: false,
+                status: "Suno URL id could not be extracted.".to_string(),
+                song_id: None,
+                metadata: None,
+                pages_checked: 0,
+                logs: vec!["id extraction failed".to_string()],
+            };
+        }
+    };
+    let agent = ureq::AgentBuilder::new().build();
+    fetch_suno_metadata_inner(&agent, &settings, &song_id)
+}
+
+#[tauri::command]
 fn generate_mp4(app: AppHandle, request: GenerateRequest) -> GenerateResponse {
     match generate_mp4_inner(app, request) {
         Ok(response) => response,
@@ -533,13 +881,35 @@ fn generate_mp4_inner(
     };
     fs::create_dir_all(&base_dir).map_err(|err| err.to_string())?;
 
-    let mp3_path = base_dir.join(format!("{id}.mp3"));
-    let cover_path = base_dir.join(format!("{id}.jpeg"));
-    let output_path = base_dir.join(format!("{id}.mp4"));
+    let filename = request
+        .output_filename
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(safe_filename)
+        .unwrap_or_else(|| id.clone());
+    let mp3_path = base_dir.join(format!("{filename}.mp3"));
+    let cover_path = base_dir.join(format!("{filename}.jpeg"));
+    let output_path = base_dir.join(format!("{filename}.mp4"));
 
     let http_agent = ureq::AgentBuilder::new().build();
-    let mp3_url = format!("https://cdn1.suno.ai/{id}.mp3");
-    let cover_url = format!("https://cdn2.suno.ai/{id}.jpeg");
+    let fallback_mp3_url = format!("https://cdn1.suno.ai/{id}.mp3");
+    let fallback_cover_url = format!("https://cdn2.suno.ai/{id}.jpeg");
+    let mp3_url = select_audio_source(None, &fallback_mp3_url);
+    let cover_url = select_cover_source(
+        request.base64.as_deref(),
+        Some(&SunoMetadata {
+            image_url: request.metadata_image_url.clone(),
+            image_large_url: request.metadata_image_url.clone(),
+            ..SunoMetadata::default()
+        }),
+        &fallback_cover_url,
+    );
+    let mp3_url = request
+        .audio_url
+        .as_deref()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or(&mp3_url)
+        .to_string();
     let has_frontend_cover = request.base64.is_some();
     warm_up_direct_downloads(
         &http_agent,
@@ -573,6 +943,7 @@ fn generate_mp4_inner(
         ffmpeg_path,
         encoder_preset,
         quality,
+        ..AppSettings::default()
     };
     match run_ffmpeg_with_settings(&args, &ffmpeg_settings) {
         Ok((stdout, stderr)) => Ok(GenerateResponse {
@@ -593,7 +964,8 @@ pub fn run() {
             save_settings,
             detect_ffmpeg,
             test_ffmpeg,
-            open_output_folder
+            open_output_folder,
+            fetch_suno_metadata
         ])
         .run(tauri::generate_context!())
         .expect("error while running Tauri application");
@@ -609,7 +981,105 @@ mod tests {
             extract_suno_id("https://suno.com/song/123e4567-e89b-12d3-a456-426614174000"),
             Some("123e4567-e89b-12d3-a456-426614174000".to_string())
         );
+        assert_eq!(
+            extract_suno_id("https://suno.com/s/123e4567-e89b-12d3-a456-426614174000"),
+            Some("123e4567-e89b-12d3-a456-426614174000".to_string())
+        );
+        assert_eq!(
+            extract_suno_id("https://www.suno.com/s/123e4567-e89b-12d3-a456-426614174000?foo=bar"),
+            Some("123e4567-e89b-12d3-a456-426614174000".to_string())
+        );
         assert_eq!(extract_suno_id("https://suno.com/"), None);
+    }
+
+    #[test]
+    fn masks_sensitive_values() {
+        assert_eq!(mask_secret("Bearer abcdefghij"), "Bearer abc...hij");
+        assert_eq!(mask_secret("abcdefghi"), "abc...ghi");
+        assert_eq!(mask_secret("abc"), "***");
+        assert_eq!(mask_secret(""), "");
+    }
+
+    #[test]
+    fn detects_suno_api_settings() {
+        assert!(!has_suno_api_settings(&AppSettings::default()));
+        assert!(has_suno_api_settings(&AppSettings {
+            suno_authorization: "Bearer token".to_string(),
+            suno_browser_token: "browser".to_string(),
+            suno_device_id: "device".to_string(),
+            ..AppSettings::default()
+        }));
+    }
+
+    #[test]
+    fn finds_matching_clip_by_id() {
+        let clips = vec![
+            SunoMetadata {
+                id: Some("a".to_string()),
+                title: Some("First".to_string()),
+                ..SunoMetadata::default()
+            },
+            SunoMetadata {
+                id: Some("b".to_string()),
+                title: Some("Second".to_string()),
+                ..SunoMetadata::default()
+            },
+        ];
+
+        assert_eq!(
+            find_matching_clip(&clips, "b").and_then(|clip| clip.title),
+            Some("Second".to_string())
+        );
+        assert_eq!(find_matching_clip(&clips, "c"), None);
+    }
+
+    #[test]
+    fn empty_feed_result_stops_pagination_path() {
+        let value = serde_json::json!([]);
+        assert!(clips_from_feed_value(&value).is_empty());
+    }
+
+    #[test]
+    fn selects_metadata_audio_when_available() {
+        let metadata = SunoMetadata {
+            audio_url: Some("https://example.test/audio.mp3".to_string()),
+            ..SunoMetadata::default()
+        };
+
+        assert_eq!(
+            select_audio_source(Some(&metadata), "https://cdn1.suno.ai/id.mp3"),
+            "https://example.test/audio.mp3"
+        );
+        assert_eq!(
+            select_audio_source(None, "https://cdn1.suno.ai/id.mp3"),
+            "https://cdn1.suno.ai/id.mp3"
+        );
+    }
+
+    #[test]
+    fn preserves_frontend_cover_priority() {
+        let metadata = SunoMetadata {
+            image_url: Some("https://example.test/image.jpeg".to_string()),
+            image_large_url: Some("https://example.test/large.jpeg".to_string()),
+            ..SunoMetadata::default()
+        };
+
+        assert_eq!(
+            select_cover_source(
+                Some("data:image/png;base64,abc"),
+                Some(&metadata),
+                "https://cdn2.suno.ai/id.jpeg"
+            ),
+            "data:image/png;base64,abc"
+        );
+        assert_eq!(
+            select_cover_source(None, Some(&metadata), "https://cdn2.suno.ai/id.jpeg"),
+            "https://example.test/large.jpeg"
+        );
+        assert_eq!(
+            select_cover_source(None, None, "https://cdn2.suno.ai/id.jpeg"),
+            "https://cdn2.suno.ai/id.jpeg"
+        );
     }
 
     #[test]

--- a/test/renderer.test.js
+++ b/test/renderer.test.js
@@ -18,3 +18,23 @@ test('renderer stores dropped images as data urls for generation', () => {
   assert.match(source, /reader\.readAsDataURL\(file\)/);
   assert.match(source, /previewImg\.setAttribute\("data-base64", base64\)/);
 });
+
+test('renderer supports Suno short URL ids and metadata fetch command', () => {
+  const source = fs.readFileSync('public/renderer.js', 'utf8');
+  assert.match(source, /suno\\\.com\\\/\(\?:song\|s\)\\\//);
+  assert.match(source, /invoke\("fetch_suno_metadata"/);
+});
+
+test('renderer keeps frontend cover priority over metadata cover', () => {
+  const source = fs.readFileSync('public/renderer.js', 'utf8');
+  assert.match(source, /const selectCoverSource = \(frontendData, metadata, fallback\) => \{/);
+  assert.match(source, /if \(frontendData\) return frontendData;/);
+});
+
+test('renderer passes metadata sources as optional generation fallbacks', () => {
+  const source = fs.readFileSync('public/renderer.js', 'utf8');
+  assert.match(source, /const metadataForRequest = currentSongId === id \? currentMetadata : null/);
+  assert.match(source, /audioUrl: metadataForRequest\?\.audioUrl \|\| null/);
+  assert.match(source, /metadataImageUrl: metadataForRequest\?\.imageLargeUrl \|\| metadataForRequest\?\.imageUrl \|\| null/);
+  assert.match(source, /outputFilename: metadataForRequest\?\.title \|\| null/);
+});


### PR DESCRIPTION
````markdown id="pr-add-suno-metadata-ux"
## Summary

Add optional Suno metadata fetching and reorganize the UI into collapsible detail panels.

## Changes

- Added collapsible panels:
  - Render Settings
  - Suno API Settings
  - Metadata
  - Lyrics
  - Style / Prompt
  - Log
- Added optional Suno API settings:
  - authorization
  - browser-token
  - device-id
  - max pages
- Stored Suno API settings in the existing settings JSON.
- Added `fetch_suno_metadata` Tauri command.
- Added metadata fetch from:

```text
https://studio-api-prod.suno.com/api/feed/?page={page}
````

* Added Suno URL ID extraction for:

  * `/s/{id}`
  * `/song/{id}`
  * URLs with query strings
* Added metadata display for:

  * title
  * id
  * display_name
  * created_at
  * audio_url
  * image_url
  * image_large_url
  * video_url
* Added Lyrics panel for `lyrics`.
* Added Style / Prompt panel for `prompt`.
* Added detailed process log panel.
* Kept the main screen lightweight with one-line status and preview/result information.

## Metadata behavior

Suno API settings are optional. The app remains usable without them.

When metadata is available:

* `title` is used as the output filename candidate.
* `audio_url` is preferred over the constructed CDN audio URL.
* `image_large_url` / `image_url` are used only as fallback cover sources after frontend cover data or dropped image data URL.

Existing cover priority is preserved:

```text
1. frontend cover data / dropped image data URL
2. metadata image URL fallback
3. direct CDN cover fallback
```

## Security / logging

* Sensitive Suno API values are password inputs in the UI.
* Logs use masked values.
* Full `authorization`, `browser-token`, and `device-id` values are not logged.
* Suno API values are stored locally in the existing app settings JSON.

## Preserved behavior

* Existing MP4 generation behavior is unchanged.
* Existing FFmpeg path settings are preserved.
* Existing output folder settings are preserved.
* Existing encoder / quality settings are preserved.
* Existing frontend cover data / dropped image data URL priority is preserved.
* Metadata fetch failure does not block preview or generation if fallback paths can still work.

## Verification

* `cargo check --manifest-path src-tauri/Cargo.toml`: pass
* `cargo test --manifest-path src-tauri/Cargo.toml`: pass, 14 tests
* `npm test`: pass, 6 tests
* `npm start`: not run
* Manual GUI verification: not run

## Commit

* `f1cad18` — Add optional Suno metadata fetch and collapsible UX panels

## Branch

`add-suno-metadata-ux`

## Artifact guard

No generated files, build artifacts, installer files, node_modules, target directory, or FFmpeg binaries should be committed.

```
```
