### PR TITLE
Document safe Suno upstream integration

### DIFF
--- a/contracts/suno_asset_payload.spec.yaml
+++ b/contracts/suno_asset_payload.spec.yaml
@@ -1,0 +1,85 @@
+version: 1
+
+component:
+  name: Suno Asset Payload
+
+purpose:
+  description: >-
+    Defines credential-free asset references sent from a browser-side Suno
+    adapter to the desktop application through Browser Bridge.
+
+transport:
+  bridge_contract: contracts/browser_bridge.spec.yaml
+  content_type: application/json
+
+security:
+  browser_credentials:
+    receive: false
+    store: false
+    log: false
+  raw_request_headers:
+    receive: false
+    store: false
+    log: false
+
+payload:
+  required:
+    request_id:
+      type: string
+      non_empty: true
+    song_id:
+      type: string
+      non_empty: true
+
+  optional:
+    audio:
+      type: object
+    cover:
+      type: object
+    video:
+      type: object
+
+asset:
+  optional:
+    url:
+      type: string
+    mime_type:
+      type: string
+    size_bytes:
+      type: integer
+      minimum: 0
+    width:
+      type: integer
+      minimum: 1
+    height:
+      type: integer
+      minimum: 1
+    source:
+      type: string
+    observed_on:
+      type: string
+
+selection:
+  audio_priority:
+    - normalized_metadata
+    - validated_fallback
+  cover_priority:
+    - custom_user_image
+    - image_large_url
+    - image_url
+    - application_fallback
+  video_priority:
+    - normalized_metadata
+    - absent
+
+validation:
+  allowed_schemes:
+    - https
+  reject_embedded_credentials: true
+  reject_local_file_urls_from_browser: true
+  max_url_chars: 4096
+
+failure_policy:
+  unavailable_audio: error
+  unavailable_cover: use_application_fallback
+  unavailable_video: continue_without_source_video

--- a/contracts/suno_metadata_payload.spec.yaml
+++ b/contracts/suno_metadata_payload.spec.yaml
@@ -1,0 +1,97 @@
+version: 1
+
+component:
+  name: Suno Metadata Payload
+
+purpose:
+  description: >-
+    Defines credential-free normalized song metadata sent from a browser-side
+    Suno adapter to the desktop application through Browser Bridge.
+
+transport:
+  bridge_contract: contracts/browser_bridge.spec.yaml
+  content_type: application/json
+
+security:
+  forbidden_fields:
+    - cookie
+    - cookies
+    - authorization
+    - authorization_header
+    - browser_token
+    - device_id
+    - clerk_token
+    - session_token
+    - google_credentials
+
+payload:
+  required:
+    request_id:
+      type: string
+      non_empty: true
+    song:
+      type: object
+
+  song:
+    required:
+      id:
+        type: string
+        non_empty: true
+
+    optional:
+      title:
+        type: string
+      display_name:
+        type: string
+      created_at:
+        type: string
+      status:
+        type: string
+      duration_seconds:
+        type: number
+        minimum: 0
+      lyrics:
+        type: string
+      prompt:
+        type: string
+      style:
+        type: string
+      tags:
+        type: array
+        items: string
+      model:
+        type: object
+      source:
+        type: object
+
+  model:
+    optional:
+      label:
+        type: string
+      identifier:
+        type: string
+      observed_on:
+        type: string
+      verified:
+        type: boolean
+
+  source:
+    optional:
+      adapter:
+        type: string
+      observed_on:
+        type: string
+      page_url:
+        type: string
+      method:
+        type: string
+
+validation:
+  reject_unknown_credential_fields: true
+  max_payload_mb: 2
+  max_tags: 100
+  max_text_chars: 100000
+
+compatibility:
+  preserve_unknown_non_secret_fields: false
+  version_required: true

--- a/docs/adr/ADR-001-browser-owned-suno-authentication.md
+++ b/docs/adr/ADR-001-browser-owned-suno-authentication.md
@@ -1,0 +1,70 @@
+# ADR-001: Browser-Owned Suno Authentication
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-17
+
+## Context
+
+`suno_mv` needs song metadata and asset references from pages that may require an authenticated Suno session.
+
+Previous approaches placed Suno authorization, browser-token, and device-id values in desktop application settings and used them from the Rust backend. This creates unnecessary credential handling and couples the desktop application to undocumented authentication details.
+
+Modern browser protections also make external cookie extraction and automated third-party login brittle.
+
+## Decision
+
+The authenticated browser owns all Suno authentication.
+
+A browser-side adapter may use the session already available to the Suno page. It sends only normalized, credential-free results to the desktop application through the localhost Browser Bridge.
+
+The desktop application must not receive, store, or log:
+
+- browser cookies
+- authorization headers
+- Clerk or session tokens
+- browser tokens
+- device identifiers
+- Google credentials
+
+Browser Bridge sessions remain localhost-only, short-lived, request-scoped, and authenticated with project-generated session credentials unrelated to Suno authentication.
+
+## Consequences
+
+### Positive
+
+- Suno credentials remain inside the browser security boundary.
+- The desktop application does not depend on Chrome cookie storage or OAuth automation.
+- Undocumented Suno response formats can be isolated in a browser adapter.
+- Rust, UI, and FFmpeg modules consume a stable normalized payload.
+
+### Negative
+
+- A browser-side integration is required for authenticated metadata.
+- The adapter must be maintained when Suno changes its page or internal APIs.
+- Some metadata may be unavailable when the browser integration is not active.
+
+## Implementation guidance
+
+- Use `contracts/browser_bridge.spec.yaml` for transport.
+- Use `contracts/suno_metadata_payload.spec.yaml` and `contracts/suno_asset_payload.spec.yaml` for result payloads.
+- Keep direct Suno endpoint details out of renderer and FFmpeg code.
+- Record undocumented API observations under `docs/research/` with verification dates.
+
+## Rejected alternatives
+
+### Desktop-held Suno credentials
+
+Rejected because it expands the credential boundary and conflicts with the Browser Bridge security contract.
+
+### Cookie extraction from Chrome
+
+Rejected because it is brittle, browser-version-dependent, and unnecessary.
+
+### Automated Google login in a controlled browser
+
+Rejected because it is fragile and may trigger provider anti-automation protections.

--- a/docs/adr/ADR-002-deprecate-desktop-suno-credentials.md
+++ b/docs/adr/ADR-002-deprecate-desktop-suno-credentials.md
@@ -1,0 +1,87 @@
+# ADR-002: Deprecate Desktop-Held Suno Credentials
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-17
+
+## Context
+
+The current Rust settings model includes:
+
+- `suno_authorization`
+- `suno_browser_token`
+- `suno_device_id`
+
+The metadata fetch path uses these values to call an undocumented Suno feed endpoint directly from the desktop backend.
+
+ADR-001 establishes that Suno authentication belongs to the browser. The existing settings and direct feed path therefore conflict with the target architecture.
+
+## Decision
+
+Desktop-held Suno credentials and direct authenticated Suno feed access are deprecated.
+
+They will be removed through an incremental migration rather than deleted immediately.
+
+## Migration plan
+
+### Phase 1: Documentation and contracts
+
+- Record the architecture decision.
+- Define credential-free metadata and asset payload contracts.
+- Mark the existing direct-feed path as legacy in code and documentation.
+
+### Phase 2: Browser Bridge parity
+
+- Implement browser-side retrieval for the metadata required by MV generation.
+- Send normalized metadata and asset references through Browser Bridge.
+- Add contract validation and credential-field rejection.
+- Preserve existing fallback behavior for public page metadata.
+
+### Phase 3: Default path switch
+
+- Make Browser Bridge the preferred authenticated metadata path.
+- Stop requesting new Suno credential values in the UI.
+- Keep the legacy path available only behind an explicit temporary compatibility option.
+
+### Phase 4: Removal
+
+- Remove the three credential settings.
+- Remove direct authenticated feed requests from the Rust backend.
+- Remove related logs, UI fields, tests, and migration-only compatibility code.
+
+## Compatibility requirements
+
+During migration:
+
+- existing MV generation must continue to work when public page metadata is sufficient
+- custom cover and direct asset fallback behavior must remain available
+- no migration step may log stored credential values
+- Browser Bridge payloads must be rejected when credential-like fields are present
+
+## Consequences
+
+### Positive
+
+- Aligns implementation with the Browser Bridge contract.
+- Reduces sensitive configuration and support burden.
+- Isolates Suno-specific undocumented behavior in the browser adapter.
+
+### Negative
+
+- Requires a staged implementation and temporary coexistence of old and new paths.
+- Users relying on manually entered credentials will need to migrate.
+
+## Follow-up work
+
+Create implementation issues for:
+
+1. legacy-path annotations and UI deprecation messaging
+2. browser metadata adapter
+3. metadata payload validation
+4. asset payload validation
+5. default-path switch
+6. credential-setting removal

--- a/docs/research/suno-internal-api-observations.md
+++ b/docs/research/suno-internal-api-observations.md
@@ -1,0 +1,73 @@
+# Suno Internal API Observations
+
+## Status
+
+Research notes only. Suno internal endpoints are undocumented and are not project contracts.
+
+## Current repository observation
+
+The current Rust backend contains a legacy metadata path that requests:
+
+```text
+https://studio-api-prod.suno.com/api/feed/?page={page}
+```
+
+and supplies desktop-held authorization, browser-token, and device-id settings.
+
+This path predates the Browser Bridge security contract and is a migration target, not the preferred architecture.
+
+## External upstream claims
+
+The reviewed upstream manual reports the following endpoints and behaviors:
+
+| Area | Reported endpoint or behavior | Local status |
+|---|---|---|
+| Generation | `POST /api/generate/v2/` | Not verified; outside current product scope |
+| Library | `GET /api/feed/v2?page=N` | Variant not verified; repository currently uses another feed path |
+| Billing | `GET /api/billing/info/` | Not verified; outside current product scope |
+| Assets | CDN URLs derived from a clip UUID | Partly observed through live Suno metadata and asset fallback code |
+| Pending asset | Small HTTP 403 response before completion | Not verified |
+
+## Architectural use
+
+Undocumented API knowledge may be used only inside a browser-side adapter that runs in the authenticated Suno page context.
+
+The desktop application may receive normalized results through Browser Bridge. It must not receive or persist:
+
+- cookies
+- Clerk or session tokens
+- authorization headers
+- browser tokens
+- device identifiers
+- Google credentials
+
+## Observation record template
+
+Use this template for every new finding:
+
+```yaml
+observation:
+  name: ""
+  source: "manual | browser-devtools | repository | issue"
+  observed_behavior: ""
+  endpoint: ""
+  request_fields: []
+  response_fields: []
+  verified_on: "YYYY-MM-DD"
+  verified_by: ""
+  reproducible: false
+  code_dependency: false
+  change_risk: "low | medium | high | very_high"
+  notes: ""
+```
+
+## Implementation rule
+
+Before adding an undocumented endpoint to production code:
+
+1. Verify it in the browser context.
+2. Record the date and minimum required fields.
+3. Define a normalized credential-free payload.
+4. Update or add a contract.
+5. Add failure and fallback behavior.
+6. Keep the undocumented response shape out of UI and FFmpeg modules.

--- a/docs/research/suno-metadata-fields.md
+++ b/docs/research/suno-metadata-fields.md
@@ -1,0 +1,73 @@
+# Suno Metadata Fields
+
+## Purpose
+
+Define the normalized metadata vocabulary used between a browser-side Suno adapter, Browser Bridge, the Rust backend, and MV generation.
+
+This document describes project-level fields. It does not guarantee that Suno uses the same names internally.
+
+## Core song fields
+
+| Field | Type | Required | Meaning |
+|---|---|---:|---|
+| `id` | string | Yes | Suno song or clip identifier |
+| `title` | string | No | Display title |
+| `display_name` | string | No | Creator or display name |
+| `created_at` | string | No | Source creation timestamp |
+| `status` | string | No | Normalized generation or availability state |
+| `duration_seconds` | number | No | Track duration in seconds |
+| `model_label` | string | No | Human-facing model label, such as `v5.5` |
+| `model_identifier` | string | No | Dated internal identifier when observed |
+
+## Text fields
+
+| Field | Type | Required | Meaning |
+|---|---|---:|---|
+| `lyrics` | string | No | Lyrics intended for display or alignment |
+| `prompt` | string | No | Source prompt when available |
+| `style` | string | No | Normalized style description |
+| `tags` | array of strings | No | Normalized style or genre tags |
+
+## Asset fields
+
+| Field | Type | Required | Meaning |
+|---|---|---:|---|
+| `audio_url` | string | No | Preferred audio asset |
+| `video_url` | string | No | Preferred source video asset |
+| `image_url` | string | No | Standard cover image |
+| `image_large_url` | string | No | Large cover image |
+
+## Selection rules
+
+Audio:
+
+1. Use a validated `audio_url` from normalized metadata.
+2. Otherwise use a validated application fallback.
+3. Never construct a URL from an identifier unless that behavior is independently verified and documented.
+
+Cover:
+
+1. Use an explicitly supplied custom image when present.
+2. Otherwise prefer `image_large_url`.
+3. Otherwise use `image_url`.
+4. Otherwise use the application fallback.
+
+Text:
+
+1. Prefer a dedicated `lyrics` field.
+2. Treat `prompt` as lyrics only when it passes an explicit lyrics-shape check.
+3. Keep style text separate from lyrics.
+
+## Provenance
+
+Every Browser Bridge payload should include provenance metadata:
+
+```yaml
+source:
+  adapter: "suno-browser"
+  observed_on: "YYYY-MM-DD"
+  page_url: "https://suno.com/song/..."
+  method: "page-data | authenticated-fetch | user-input"
+```
+
+No provenance field may contain credentials or raw request headers.

--- a/docs/research/suno-model-identifiers.md
+++ b/docs/research/suno-model-identifiers.md
@@ -1,0 +1,40 @@
+# Suno Model Identifier Observations
+
+## Policy
+
+Suno model identifiers are undocumented implementation details. They must be recorded as dated observations, never as permanent project constants without revalidation.
+
+## Upstream-reported mapping
+
+The external manual reviewed on 2026-07-17 reports:
+
+| UI label | Reported internal identifier | Local verification | Project use |
+|---|---|---:|---|
+| v5.5 | `chirp-fenix` | No | Research only |
+| v5 | `chirp-crow` | No | Research only |
+| v4 | `chirp-v4` | No | Research only |
+| v2 | `chirp-v2` | No | Research only |
+
+The same source claims that omitting the model identifier from a generation request may select `chirp-v2`. This has not been independently verified by `suno_mv`.
+
+## Storage guidance
+
+When model information is received through Browser Bridge, preserve both forms when available:
+
+```yaml
+model:
+  label: "v5.5"
+  identifier: "chirp-fenix"
+  observed_on: "2026-07-17"
+  source: "upstream-manual"
+  verified: false
+```
+
+## Rules
+
+- Do not infer an internal identifier from a UI label.
+- Do not use an unverified mapping to initiate generation.
+- Preserve unknown identifiers rather than rejecting otherwise usable song metadata.
+- Display the UI label to users when available.
+- Keep historical identifiers for diagnostics and dataset provenance.
+- Reverify all mappings before implementing generation features.

--- a/docs/research/upstream-manual-review.md
+++ b/docs/research/upstream-manual-review.md
@@ -1,0 +1,55 @@
+# Upstream Suno Manual Review
+
+## Purpose
+
+This document evaluates claims from the external `MANUAL_SUNO_OPERATIVO.md` against the architecture and security contracts of `suno_mv`.
+
+The upstream manual is treated as time-bound operational research, not as an authoritative Suno API specification.
+
+## Review policy
+
+Each claim must be recorded with:
+
+- the claim as stated by the upstream source
+- whether it has been independently observed in `suno_mv`
+- whether `suno_mv` adopts it
+- the reason for rejection or deferral
+- the last verification date
+- the risk that Suno may change the behavior
+
+## Review table
+
+| Claim | Observed in `suno_mv` | Adopt | Rejection or deferral reason | Verified on | Change risk |
+|---|---:|---:|---|---|---|
+| Browser-owned authentication is more reliable than extracting Chrome cookies | Partly | Yes | Aligns with the Browser Bridge contract and avoids exporting browser credentials | 2026-07-17 | Medium |
+| A temporary Clerk token can be obtained in the Suno page context | No | No | Authentication material must not cross the browser boundary | Not verified | High |
+| Suno feed responses contain reusable song metadata | Yes | Yes | Metadata is already normalized by the Rust backend; future collection should happen in the browser adapter | 2026-07-17 | High |
+| Suno audio and cover assets can be resolved from metadata or CDN URLs | Yes | Yes | Required for MV generation, with fallback and validation | 2026-07-17 | Medium |
+| Model labels map to stable internal `mv` identifiers | No | Research only | Internal identifiers are undocumented and may change without notice | Not verified | Very high |
+| Omitting `mv` selects an old model | No | No | Not independently verified and generation is outside the current application scope | Not verified | Very high |
+| One generation request always returns two variants | No | Research only | Not required for current MV generation features | Not verified | High |
+| HTTP 403 from an audio URL means generation is still pending | No | Research only | Status semantics must be verified before implementation | Not verified | High |
+| Randomized delays and warm windows should be used to sustain automated generation | No | No | Rate-limit or challenge circumvention is outside project scope | Not verified | Very high |
+| CAPTCHA or Turnstile tokens should be captured and reused | No | No | Conflicts with security boundaries and service protections | Not verified | Very high |
+| Completed, non-trashed tracks above a duration threshold are useful dataset candidates | No | Deferred | Dataset production is not currently a `suno_mv` responsibility | Not verified | Medium |
+
+## Adoption boundary
+
+The project may adopt:
+
+- metadata field observations
+- asset selection and fallback rules
+- completion-state observations after independent verification
+- model identifiers as dated research notes only
+- payload schemas that contain song data but no browser credentials
+
+The project must not adopt:
+
+- exporting cookies, session tokens, authorization headers, browser tokens, or device identifiers
+- storing Suno authentication in desktop settings
+- CAPTCHA token collection or reuse
+- deliberate evasion of rate limits or anti-automation controls
+
+## Verification rule
+
+Any observation about an undocumented Suno endpoint must include a verification date and must be revalidated before code depends on it.


### PR DESCRIPTION
## What changed

- adds a structured review of `MANUAL_SUNO_OPERATIVO.md`
- records Suno internal API and model identifier observations as dated research rather than stable specifications
- defines normalized credential-free metadata and asset payload contracts
- accepts browser-owned Suno authentication as the target architecture
- deprecates desktop-held Suno authorization, browser-token, and device-id settings through a staged migration ADR

## Why

The external manual contains useful observations, but directly importing its authentication and automation practices would conflict with the existing Browser Bridge security boundary. This PR separates reusable metadata knowledge from unverified or rejected operational techniques.

## Impact

Documentation and contracts only. No runtime behavior changes.

## Validation

- reviewed the upstream claim table on the branch
- confirmed the new files are isolated under `docs/research`, `docs/adr`, and `contracts`
- no build or runtime tests required for this documentation-only change
